### PR TITLE
Added innovation site.

### DIFF
--- a/innovation.js
+++ b/innovation.js
@@ -1,0 +1,17 @@
+// @see https://github.com/garris/BackstopJS
+
+const siteConfig = {
+  live: "https://innovation.ca.gov",
+  test: "http://localhost:8080",
+  pagesToTest: [
+    { home: '' },
+    { page: 'who-we-are/our-vision/' },
+    { project: 'our-work/projects/getting-compensation-to-more-california-crime-victims/' }, 
+    { blogindex: 'blog/' }, 
+    { blogarticle: 'blog/posts/helping-californians-have-a-voice-in-toxic-cleanup-projects/' }, 
+    { notFound: 'snertfoodle' }, // 404
+  ],
+  readySelectorToTest: "body"
+}
+
+module.exports = siteConfig;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cagov-backstop",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "backstoptests",
   "main": "backstop.js",
   "scripts": {
@@ -13,7 +13,8 @@
     "test:cannabisCombobox": "SITE=cannabis backstop reference --config=backstop.js && SITE=cannabisCombobox  backstop test --config=backstop.js",
     "test:drought": "SITE=drought backstop reference --config=backstop.js && SITE=drought backstop test --config=backstop.js",
     "test:designSystem": "SITE=designSystem backstop reference --config=backstop.js && SITE=designSystem backstop test --config=backstop.js",
-    "test:abortion": "SITE=abortion backstop reference --config=backstop.js && SITE=abortion backstop test --config=backstop.js"
+    "test:abortion": "SITE=abortion backstop reference --config=backstop.js && SITE=abortion backstop test --config=backstop.js",
+    "test:innovation": "SITE=innovation backstop reference --config=backstop.js && SITE=innovation  backstop test --config=backstop.js"
   },
   "author": "Zakiya Khabir",
   "license": "MIT",


### PR DESCRIPTION
Added config for innovation.ca.gov .

The site is currently passing when tested against a version from prior to the Wordpress upgrade. 

There are just a few false positives, due to a difference in handling 404s, and differing PAR scores (which are a bit random).